### PR TITLE
Add Android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace 'dev.jerson.fat_rsa'
+    }
     compileSdkVersion 31
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 android {
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
-      namespace 'dev.jerson.fat_rsa'
+      namespace 'dev.jerson.fast_rsa'
     }
     compileSdkVersion 31
 


### PR DESCRIPTION
Adds a namespace attribute to the Android build.gradle, for compatibility with Android Gradle Plugin 8.0. See: https://github.com/flutter/packages/commit/6284c2d4e46a5d289e77cb03a9457543b97f750b

Message that you can use for the changelog:

> Adds a namespace for compatibility with AGP 8.0.

Fixes https://github.com/jerson/flutter-rsa/issues/66