### PR TITLE
[WASM] migrate to package:web and dart:js_interop

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -491,6 +491,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -524,5 +532,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/example/web/index.html
+++ b/example/web/index.html
@@ -30,16 +30,6 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
-  <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('flutter-first-frame', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
-    }
-  </script>
-  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/lib/bridge/ffi.dart
+++ b/lib/bridge/ffi.dart
@@ -12,7 +12,7 @@ typedef Call = ffi.Pointer<FFIBytesReturn> Function(
   int,
 );
 
-class FFIBytesReturn extends ffi.Struct {
+final class FFIBytesReturn extends ffi.Struct {
   external ffi.Pointer<ffi.Void> message;
 
   @ffi.Int32()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.6.3
 homepage: https://github.com/jerson/flutter-rsa
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: ">=1.10.0"
 
 false_secrets:
@@ -18,6 +18,7 @@ dependencies:
   ffi: ^2.0.1
   flat_buffers: ^2.0.5
   path: ^1.8.2
+  web: ">=0.5.0 <2.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In order to [support web assembly](https://docs.flutter.dev/platform-integration/web/wasm), the package need to be migrated to `package:web` and `dart:js_interop` instead of `dart:html` and `package:js`