### PR TITLE
Fix build on web

### DIFF
--- a/lib/web/rsa_web.dart
+++ b/lib/web/rsa_web.dart
@@ -7,9 +7,7 @@ import 'package:web/web.dart';
 
 class FastRsaPlugin {
   var _counter = 0;
-  Worker worker = Worker(
-    'assets/packages/fast_rsa/web/assets/worker.js'.toJS,
-  );
+  Worker worker = Worker('assets/packages/fast_rsa/web/assets/worker.js');
   Map<String, Completer<Uint8List>> completers = {};
 
   static void registerWith(Registrar registrar) {


### PR DESCRIPTION
This fixes the invalid type used in `rsa_web.dart` causing it to not build.